### PR TITLE
Early Preview: Let GitHub integration show changes in a separate tab

### DIFF
--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -1,0 +1,45 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+en:
+  js:
+    github_integration:
+      work_packages:
+        tab_name: "GitHub"
+      pull_request_opened_comment: >
+        **PR Opened:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been opened by [%{github_user}](%{github_user_url}).
+      pull_request_closed_comment: >
+        **PR Closed:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been closed by [%{github_user}](%{github_user_url}).
+      pull_request_merged_comment: >
+        **PR Merged:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been merged by [%{github_user}](%{github_user_url}).
+      pull_request_referenced_comment: >
+        **Referenced in PR:** [%{github_user}](%{github_user_url}) referenced this work package in
+        Pull request %{pr_number} [%{pr_title}](%{pr_url}) on [%{repository}](%{repository_url}).

--- a/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
+++ b/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
@@ -1,0 +1,52 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {Component, Input, OnInit} from "@angular/core";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import { TabComponent } from '../../../../../components/wp-single-view-tabs/additional-tab/tab.component';
+
+
+@Component({
+  selector: 'github-tab',
+  templateUrl: './github-tab.template.html'
+})
+export class GitHubTabComponent implements OnInit, TabComponent {
+  @Input() public workPackage:WorkPackageResource;
+
+  constructor(readonly PathHelper:PathHelperService,
+              readonly I18n:I18nService) {
+  }
+
+
+  ngOnInit() {
+    // debugger; // when triggered we know we can render ANYTHING here
+  }
+}
+

--- a/modules/github_integration/frontend/module/github-tab/github-tab.template.html
+++ b/modules/github_integration/frontend/module/github-tab/github-tab.template.html
@@ -1,0 +1,1 @@
+<div>Hello from the GitHub integration plugin</div>

--- a/modules/github_integration/frontend/module/main.ts
+++ b/modules/github_integration/frontend/module/main.ts
@@ -1,0 +1,59 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+
+import {Injector, NgModule} from '@angular/core';
+import {OpenProjectPluginContext} from 'core-app/modules/plugins/plugin-context';
+import {GitHubTabComponent} from './github-tab/github-tab.component';
+import {Tab} from "../../../../components/wp-single-view-tabs/additional-tab/tab";
+
+export function initializeGithubIntegrationPlugin(injector:Injector) {
+  window.OpenProject.getPluginContext().then((pluginContext:OpenProjectPluginContext) => {
+    pluginContext.registerAdditionalWorkPackageTab(
+      new Tab(
+        GitHubTabComponent,
+        I18n.t('js.github_integration.work_packages.tab_name'),
+        "github"
+      )
+    )
+  });
+}
+
+
+@NgModule({
+  providers: [
+  ],
+  declarations: [
+    GitHubTabComponent
+  ]
+})
+export class PluginModule {
+  constructor(injector:Injector) {
+    initializeGithubIntegrationPlugin(injector);
+  }
+}
+
+
+

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -34,6 +34,16 @@ module OpenProject::GithubIntegration
   class Engine < ::Rails::Engine
     engine_name :openproject_github_integration
 
+    # TODO, see: modules/backlogs/lib/open_project/backlogs/engine.rb
+    # def self.settings
+    #   { default: { 'story_types'  => nil,
+    #                'task_type'    => nil,
+    #                'card_spec'    => nil
+    #   },
+    #     partial: 'shared/settings',
+    #     menu_item: :backlogs_settings }
+    # end
+
     include OpenProject::Plugins::ActsAsOpEngine
 
     register 'openproject-github_integration',
@@ -54,5 +64,18 @@ module OpenProject::GithubIntegration
                                              &NotificationHandlers.method(:issue_comment))
     end
 
+    initializer 'github.permissions' do
+      OpenProject::AccessControl.map do |map|
+        map.project_module(:github, {}) do |map|
+          map.permission(:show_github_content, {}, {})
+        end
+      end
+    end
+
+    extend_api_response(:v3, :work_packages, :work_package) do
+      require_relative 'patches/api/v3/additional_work_package_tabs'
+
+      prepend Patches::API::V3::AdditionalWorkPackageTabs
+    end
   end
 end

--- a/modules/github_integration/lib/open_project/github_integration/patches/api/v3/additional_work_package_tabs.rb
+++ b/modules/github_integration/lib/open_project/github_integration/patches/api/v3/additional_work_package_tabs.rb
@@ -1,0 +1,11 @@
+module OpenProject::GithubIntegration::Patches
+  module API::V3::AdditionalWorkPackageTabs
+    def additional_work_package_tabs
+      if represented.project.module_enabled?(:github) && current_user.allowed_to?(:show_github_content, represented.project)
+        super + [:github]
+      else
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an early preview of my work of enhancing the GitHub Integration.
It demos the new interface to add additional tabs in OP core.

Before reviewing this PR, please take a look at https://github.com/opf/openproject/pull/8988